### PR TITLE
Add type checking via phpstan

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,3 +13,4 @@
 /art                     export-ignore
 /docs                    export-ignore
 /UPGRADING.md            export-ignore
+/types                   export-ignore

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     },
     "require-dev": {
         "pestphp/pest": "^1.20",
+        "phpstan/phpstan": "^1.4",
         "spatie/ray": "^1.28"
     },
     "autoload": {

--- a/src/Invader.php
+++ b/src/Invader.php
@@ -4,11 +4,19 @@ namespace Spatie\Invade;
 
 use ReflectionClass;
 
+/**
+ * @template T of object
+ * @mixin T
+ */
 class Invader
 {
+    /** @var T */
     public object $obj;
     public ReflectionClass $reflected;
 
+    /**
+     * @param T $obj
+     */
     public function __construct(object $obj)
     {
         $this->obj = $obj;

--- a/src/functions.php
+++ b/src/functions.php
@@ -3,7 +3,13 @@
 use Spatie\Invade\Invader;
 
 if (! function_exists('invade')) {
-    function invade(object $object)
+    /**
+     * @template T of object
+     *
+     * @param T $object
+     * @return Invader<T>
+     */
+    function invade(object $object): Invader
     {
         return new Invader($object);
     }

--- a/types/Example.php
+++ b/types/Example.php
@@ -1,0 +1,16 @@
+<?php
+
+class Example
+{
+    public function __construct(
+        private string $mySecret,
+        protected int $myShared,
+        public string $myExposed,
+    ) {
+    }
+
+    public function getMySecret(): string
+    {
+        return $this->mySecret;
+    }
+}

--- a/types/phpstan.neon.dist
+++ b/types/phpstan.neon.dist
@@ -1,0 +1,4 @@
+parameters:
+  paths:
+    - .
+  level: max

--- a/types/src/Invader.php
+++ b/types/src/Invader.php
@@ -1,0 +1,12 @@
+<?php
+
+use Spatie\Invade\Invader;
+use function PHPStan\Testing\assertType;
+
+$example = new Example("password", 42, "Pestival");
+$invaded = new Invader($example);
+
+assertType(Invader::class . '<' . Example::class . '>', $invaded);
+assertType('string', $invaded->myExposed);
+assertType('int', $invaded->myShared);
+assertType('string', $invaded->mySecret);

--- a/types/src/functions.php
+++ b/types/src/functions.php
@@ -1,0 +1,8 @@
+<?php
+
+use Spatie\Invade\Invader;
+use function PHPStan\Testing\assertType;
+
+$example = new Example("password", 42, "Pestival");
+
+assertType(Invader::class . '<' . Example::class . '>', invade($example));


### PR DESCRIPTION
Added type checking via phpstan, unfortunately it is not flawless as the tests for accessing the protected and private properties fails.

Couldn't really find a way to fix that without having to do a phpstan extension.

To run it 
```
vendor/bin/phpstan --config=types/phpstan.neon.dist
```