### PR TITLE
Add phpstan support to not report access to private properties/methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,15 @@ Using `invade` you can also call private functions.
 invade($myClass)->privateMethod(); // returns 'private return value'
 ```
 
+## PHPStan
+
+PHPStan will report errors for every invaded private method and property as it is not aware that you can now access them. To remove these errors install the [PHPStan extension installer](https://github.com/phpstan/extension-installer) or add the invade PHPStan extension manually to your PHPStan configuration:
+
+```yaml
+includes:
+    - ./vendor/spatie/invade/phpstan-extension.neon
+```
+
 ## Testing
 
 ```bash

--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,13 @@
             "pestphp/pest-plugin": true
         }
     },
+    "extra": {
+        "phpstan": {
+            "includes": [
+                "phpstan-extension.neon"
+            ]
+        }
+    },
     "minimum-stability": "dev",
     "prefer-stable": true
 }

--- a/phpstan-extension.neon
+++ b/phpstan-extension.neon
@@ -1,0 +1,4 @@
+services:
+    - class: Spatie\Invade\PHPStan\InvadeReturnTypeExtension
+      tags:
+        - phpstan.broker.dynamicFunctionReturnTypeExtension

--- a/src/PHPStan/InvadeReturnTypeExtension.php
+++ b/src/PHPStan/InvadeReturnTypeExtension.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Spatie\Invade\PHPStan;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\Type;
+
+class InvadeReturnTypeExtension implements DynamicFunctionReturnTypeExtension
+{
+    public function isFunctionSupported(FunctionReflection $functionReflection): bool
+    {
+        return $functionReflection->getName() === 'invade';
+    }
+
+    public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
+    {
+        $args = $functionCall->getArgs();
+        if (! isset($args[0])) {
+            return null;
+        }
+
+        /** @var \PHPStan\Type\ObjectType $obj */
+        $obj = $scope->getType($args[0]->value);
+
+        return new InvadedObjectType($obj);
+    }
+}

--- a/src/PHPStan/InvadedMethodReflection.php
+++ b/src/PHPStan/InvadedMethodReflection.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Spatie\Invade\PHPStan;
+
+use PHPStan\Reflection\ClassMemberReflection;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\TrinaryLogic;
+use PHPStan\Type\Type;
+
+class InvadedMethodReflection implements MethodReflection
+{
+    public function __construct(
+        private MethodReflection $method,
+    ) {
+    }
+
+    public function getDeclaringClass(): ClassReflection
+    {
+        return $this->method->getDeclaringClass();
+    }
+
+    public function isStatic(): bool
+    {
+        return $this->method->isStatic();
+    }
+
+    public function isPrivate(): bool
+    {
+        return false;
+    }
+
+    public function isPublic(): bool
+    {
+        return true;
+    }
+
+    public function getDocComment(): ?string
+    {
+        return $this->method->getDocComment();
+    }
+
+    public function getName(): string
+    {
+        return $this->method->getName();
+    }
+
+    public function getPrototype(): ClassMemberReflection
+    {
+        return $this->method->getPrototype();
+    }
+
+    public function getVariants(): array
+    {
+        return $this->method->getVariants();
+    }
+
+    public function isDeprecated(): TrinaryLogic
+    {
+        return $this->method->isDeprecated();
+    }
+
+    public function getDeprecatedDescription(): ?string
+    {
+        return $this->method->getDeprecatedDescription();
+    }
+
+    public function isFinal(): TrinaryLogic
+    {
+        return $this->method->isFinal();
+    }
+
+    public function isInternal(): TrinaryLogic
+    {
+        return $this->method->isInternal();
+    }
+
+    public function getThrowType(): ?Type
+    {
+        return $this->method->getThrowType();
+    }
+
+    public function hasSideEffects(): TrinaryLogic
+    {
+        return $this->method->hasSideEffects();
+    }
+}

--- a/src/PHPStan/InvadedObjectType.php
+++ b/src/PHPStan/InvadedObjectType.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Spatie\Invade\PHPStan;
+
+use PHPStan\Reflection\ClassMemberAccessAnswerer;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\PropertyReflection;
+use PHPStan\Type\ObjectType;
+
+class InvadedObjectType extends ObjectType
+{
+    public function __construct(
+        private ObjectType $object,
+    ) {
+        parent::__construct($this->object->getClassName(), $this->object->getSubtractedType(), $this->object->getClassReflection());
+    }
+
+    public function getProperty(string $propertyName, ClassMemberAccessAnswerer $scope): PropertyReflection
+    {
+        return new InvadedPropertyReflection(parent::getProperty($propertyName, $scope));
+    }
+
+    public function getMethod(string $methodName, ClassMemberAccessAnswerer $scope): MethodReflection
+    {
+        return new InvadedMethodReflection(parent::getMethod($methodName, $scope));
+    }
+}

--- a/src/PHPStan/InvadedPropertyReflection.php
+++ b/src/PHPStan/InvadedPropertyReflection.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Spatie\Invade\PHPStan;
+
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\PropertyReflection;
+use PHPStan\TrinaryLogic;
+use PHPStan\Type\Type;
+
+class InvadedPropertyReflection implements PropertyReflection
+{
+    public function __construct(
+        private PropertyReflection $property,
+    ) {
+    }
+
+    public function getDeclaringClass(): ClassReflection
+    {
+        return $this->property->getDeclaringClass();
+    }
+
+    public function isStatic(): bool
+    {
+        return $this->property->isStatic();
+    }
+
+    public function isPrivate(): bool
+    {
+        return false;
+    }
+
+    public function isPublic(): bool
+    {
+        return true;
+    }
+
+    public function getDocComment(): ?string
+    {
+        return $this->property->getDocComment();
+    }
+
+    public function getReadableType(): Type
+    {
+        return $this->property->getReadableType();
+    }
+
+    public function getWritableType(): Type
+    {
+        return $this->property->getWritableType();
+    }
+
+    public function canChangeTypeAfterAssignment(): bool
+    {
+        return $this->property->canChangeTypeAfterAssignment();
+    }
+
+    public function isReadable(): bool
+    {
+        return $this->property->isReadable();
+    }
+
+    public function isWritable(): bool
+    {
+        return $this->property->isWritable();
+    }
+
+    public function isDeprecated(): TrinaryLogic
+    {
+        return $this->property->isDeprecated();
+    }
+
+    public function getDeprecatedDescription(): ?string
+    {
+        return $this->property->getDeprecatedDescription();
+    }
+
+    public function isInternal(): TrinaryLogic
+    {
+        return $this->property->isInternal();
+    }
+}


### PR DESCRIPTION
When using PHPStan together with invade it will report all the time accessing private properties and methods:

```
 ------ -------------------------------------------------------------------------------------
  Line   Console/Commands/Invade.php
 ------ -------------------------------------------------------------------------------------
  45     Call to private method hello() of class App\Console\Commands\Foo.
  46     Access to private property Spatie\Invade\Invader<App\Console\Commands\Foo>::$hello.

 [ERROR] Found 2 errors
```

You can manually silence them all with `@phpstan-ignore-next-line` but that's cluttering the source code a lot. This PR adds a custom PHPStan reflection provider which tells PHPStan to handle invaded objects differently and allow access to private/protected properties and methods.