### PR TITLE
Make global `invade()` function optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ You can install the package via composer:
 composer require spatie/invade
 ```
 
+If you want to use the global `invade()` function, add the following to `composer.json`  autoload section:
+
+```json
+"files": [
+  "vendor/spatie/invade/src/functions.php"
+]
+```
+
 ## Usage
 
 Imagine you have this class defined which has a private property and method.
@@ -48,19 +56,28 @@ $myClass = new Myclass();
 This is how you can get the value of the private property using the `invade` function.
 
 ```php
+new Spatie\Invade\Invader($myClass)->privateProperty; // returns 'private value'
+// or
 invade($myClass)->privateProperty; // returns 'private value'
 ```
 
 The `invade` function also allows you to change private values.
 
 ```php
+new Spatie\Invade\Invader($myClass)->privateProperty= 'changed value'
+// or
 invade($myClass)->privateProperty = 'changed value';
+
+new Spatie\Invade\Invader($myClass)->privateProperty; // returns 'changed value
+// or
 invade($myClass)->privateProperty; // returns 'changed value
 ```
 
 Using `invade` you can also call private functions.
 
 ```php
+new Spatie\Invade\Invader($myClass)->privateMethod(); // returns 'private return value'
+// or
 invade($myClass)->privateMethod(); // returns 'private return value'
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -25,15 +25,15 @@
     "autoload": {
         "psr-4": {
             "Spatie\\Invade\\": "src"
-        },
-        "files": [
-            "src/functions.php"
-        ]
+        }
     },
     "autoload-dev": {
         "psr-4": {
             "Spatie\\Invade\\Tests\\": "tests"
-        }
+        },
+        "files": [
+            "src/functions.php"
+        ]
     },
     "scripts": {
         "test": "vendor/bin/pest",


### PR DESCRIPTION
Hi there,

Thank you for this helpful package.

This pull removes the `invade()` function by default and adds instructions to the README on how to add it if needed. 

The reason is that not everybody wants to pollute the global namespace with extra functions. I know it makes installing a little more complicated, but the ability to opt-in is worth it. At least, I think.
