### PR TITLE
Invade static properties and methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,40 @@ Using `invade` you can also call private functions.
 invade($myClass)->privateMethod(); // returns 'private return value'
 ```
 
+Further, there is also `invadeStatic` to get and set private static class properties and call private static methods. Imagine having this class:
+
+```php
+class MyClass
+{
+    private static string $privateProperty = 'privateValue';
+
+    private static function privateMethod(string $string, int $int): string
+    {
+        return 'private return value ' . $string . ' ' . $int;
+    }
+}
+```
+
+Here is how you get and set private class properties:
+
+```php
+invadeStatic(MyClass::class)->get('privateProperty'); // returns 'private value'
+
+invadeStatic(MyClass::class)->set('privateProperty', 'changedValue');
+
+invadeStatic(MyClass::class)->get('privateProperty'); // returns 'changedValue'
+```
+
+And this is how you call private static methods:
+
+```php
+invadeStatic(MyClass::class)
+    ->method('privateMethod')
+    ->call('foo', 123);
+
+// returns 'private return value foo 123'
+```
+
 ## Testing
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ Further, you can also get and set private static class properties and call priva
 ```php
 class MyClass
 {
-    private static string $privateProperty = 'privateValue';
+    private static string $privateStaticProperty = 'privateValue';
 
-    private static function privateMethod(string $string, int $int): string
+    private static function privateStaticMethod(string $string, int $int): string
     {
         return 'private return value ' . $string . ' ' . $int;
     }
@@ -78,18 +78,18 @@ class MyClass
 Here is how you get and set private class properties:
 
 ```php
-invade(MyClass::class)->get('privateProperty'); // returns 'private value'
+invade(MyClass::class)->get('privateStaticProperty'); // returns 'private value'
 
-invade(MyClass::class)->set('privateProperty', 'changedValue');
+invade(MyClass::class)->set('privateStaticProperty', 'changedValue');
 
-invade(MyClass::class)->get('privateProperty'); // returns 'changedValue'
+invade(MyClass::class)->get('privateStaticProperty'); // returns 'changedValue'
 ```
 
 And this is how you call private static methods:
 
 ```php
 invade(MyClass::class)
-    ->method('privateMethod')
+    ->method('privateStaticMethod')
     ->call('foo', 123);
 
 // returns 'private return value foo 123'

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Using `invade` you can also call private functions.
 invade($myClass)->privateMethod(); // returns 'private return value'
 ```
 
-Further, there is also `invadeStatic` to get and set private static class properties and call private static methods. Imagine having this class:
+Further, you can also get and set private static class properties and call private static methods. Imagine having this class:
 
 ```php
 class MyClass
@@ -78,17 +78,17 @@ class MyClass
 Here is how you get and set private class properties:
 
 ```php
-invadeStatic(MyClass::class)->get('privateProperty'); // returns 'private value'
+invade(MyClass::class)->get('privateProperty'); // returns 'private value'
 
-invadeStatic(MyClass::class)->set('privateProperty', 'changedValue');
+invade(MyClass::class)->set('privateProperty', 'changedValue');
 
-invadeStatic(MyClass::class)->get('privateProperty'); // returns 'changedValue'
+invade(MyClass::class)->get('privateProperty'); // returns 'changedValue'
 ```
 
 And this is how you call private static methods:
 
 ```php
-invadeStatic(MyClass::class)
+invade(MyClass::class)
     ->method('privateMethod')
     ->call('foo', 123);
 

--- a/src/StaticInvader.php
+++ b/src/StaticInvader.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Spatie\Invade;
+
+use Exception;
+
+class StaticInvader
+{
+    private ?string $method = null;
+
+    /**
+     * @param class-string $className
+     */
+    public function __construct(
+        public string $className,
+    ) {
+    }
+
+    public function get(string $name): mixed
+    {
+        return (fn () => static::${$name})->bindTo(null, $this->className)();
+    }
+
+    public function set(string $name, mixed $value): void
+    {
+        (fn ($value) => static::${$name} = $value)->bindTo(null, $this->className)($value);
+    }
+
+    public function method(string $name): self
+    {
+        $this->method = $name;
+
+        return $this;
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function call(...$params): mixed
+    {
+        if ($this->method === null) {
+            throw new Exception(
+                'No method to be called. Use it like: invadeStatic(Foo::class)->method(\'bar\')->call()'
+            );
+        }
+
+        return (fn ($method) => static::{$method}(...$params))->bindTo(null, $this->className)($this->method);
+    }
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,6 +1,7 @@
 <?php
 
 use Spatie\Invade\Invader;
+use Spatie\Invade\StaticInvader;
 
 if (! function_exists('invade')) {
     /**
@@ -12,5 +13,16 @@ if (! function_exists('invade')) {
     function invade(object $object): Invader
     {
         return new Invader($object);
+    }
+}
+
+if (! function_exists('invadeStatic')) {
+    /**
+     * @param class-string $class
+     * @return StaticInvader
+     */
+    function invadeStatic(string $class): StaticInvader
+    {
+        return new StaticInvader($class);
     }
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -7,22 +7,15 @@ if (! function_exists('invade')) {
     /**
      * @template T of object
      *
-     * @param T $object
-     * @return Invader<T>
+     * @param T|class-string $object
+     * @return Invader<T>|StaticInvader
      */
-    function invade(object $object): Invader
+    function invade(object|string $object): Invader|StaticInvader
     {
-        return new Invader($object);
-    }
-}
+        if (is_object($object)) {
+            return new Invader($object);
+        }
 
-if (! function_exists('invadeStatic')) {
-    /**
-     * @param class-string $class
-     * @return StaticInvader
-     */
-    function invadeStatic(string $class): StaticInvader
-    {
-        return new StaticInvader($class);
+        return new StaticInvader($object);
     }
 }

--- a/tests/Example.php
+++ b/tests/Example.php
@@ -4,9 +4,9 @@ namespace Spatie\Invade\Tests;
 
 class Example
 {
-    private static string $privateProperty = 'privateValue';
+    private static string $privateStaticProperty = 'privateValue';
 
-    private static function privateMethod(string $string, int $int): string
+    private static function privateStaticMethod(string $string, int $int): string
     {
         return 'private return value ' . $string . ' ' . $int;
     }

--- a/tests/Example.php
+++ b/tests/Example.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\Invade\Tests;
+
+class Example
+{
+    private static string $privateProperty = 'privateValue';
+
+    private static function privateMethod(string $string, int $int): string
+    {
+        return 'private return value ' . $string . ' ' . $int;
+    }
+}

--- a/tests/StaticInvaderTest.php
+++ b/tests/StaticInvaderTest.php
@@ -3,28 +3,28 @@
 namespace Spatie\Invade\Tests;
 
 beforeEach(function () {
-    if (invade(Example::class)->get('privateProperty') === 'changedValue') {
-        invade(Example::class)->set('privateProperty', 'privateValue');
+    if (invade(Example::class)->get('privateStaticProperty') === 'changedValue') {
+        invade(Example::class)->set('privateStaticProperty', 'privateValue');
     }
 });
 
 it('reads a static private property', function () {
-    $privateValue = invade(Example::class)->get('privateProperty');
+    $privateValue = invade(Example::class)->get('privateStaticProperty');
 
     expect($privateValue)->toBe('privateValue');
 });
 
 it('sets a private static property', function () {
-    invade(Example::class)->set('privateProperty', 'changedValue');
+    invade(Example::class)->set('privateStaticProperty', 'changedValue');
 
-    $privateValue = invade(Example::class)->get('privateProperty');
+    $privateValue = invade(Example::class)->get('privateStaticProperty');
 
     expect($privateValue)->toBe('changedValue');
 });
 
 it('calls a private static method', function () {
     $returnValue = invade(Example::class)
-        ->method('privateMethod')
+        ->method('privateStaticMethod')
         ->call('test', 123);
 
     expect($returnValue)->toBe('private return value test 123');

--- a/tests/StaticInvaderTest.php
+++ b/tests/StaticInvaderTest.php
@@ -3,27 +3,27 @@
 namespace Spatie\Invade\Tests;
 
 beforeEach(function () {
-    if (invadeStatic(Example::class)->get('privateProperty') === 'changedValue') {
-        invadeStatic(Example::class)->set('privateProperty', 'privateValue');
+    if (invade(Example::class)->get('privateProperty') === 'changedValue') {
+        invade(Example::class)->set('privateProperty', 'privateValue');
     }
 });
 
 it('reads a static private property', function () {
-    $privateValue = invadeStatic(Example::class)->get('privateProperty');
+    $privateValue = invade(Example::class)->get('privateProperty');
 
     expect($privateValue)->toBe('privateValue');
 });
 
 it('sets a private static property', function () {
-    invadeStatic(Example::class)->set('privateProperty', 'changedValue');
+    invade(Example::class)->set('privateProperty', 'changedValue');
 
-    $privateValue = invadeStatic(Example::class)->get('privateProperty');
+    $privateValue = invade(Example::class)->get('privateProperty');
 
     expect($privateValue)->toBe('changedValue');
 });
 
 it('calls a private static method', function () {
-    $returnValue = invadeStatic(Example::class)
+    $returnValue = invade(Example::class)
         ->method('privateMethod')
         ->call('test', 123);
 

--- a/tests/StaticInvaderTest.php
+++ b/tests/StaticInvaderTest.php
@@ -2,6 +2,12 @@
 
 namespace Spatie\Invade\Tests;
 
+beforeEach(function () {
+    if (invadeStatic(Example::class)->get('privateProperty') === 'changedValue') {
+        invadeStatic(Example::class)->set('privateProperty', 'privateValue');
+    }
+});
+
 it('reads a static private property', function () {
     $privateValue = invadeStatic(Example::class)->get('privateProperty');
 

--- a/tests/StaticInvaderTest.php
+++ b/tests/StaticInvaderTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Spatie\Invade\Tests;
+
+it('reads a static private property', function () {
+    $privateValue = invadeStatic(Example::class)->get('privateProperty');
+
+    expect($privateValue)->toBe('privateValue');
+});
+
+it('sets a private static property', function () {
+    invadeStatic(Example::class)->set('privateProperty', 'changedValue');
+
+    $privateValue = invadeStatic(Example::class)->get('privateProperty');
+
+    expect($privateValue)->toBe('changedValue');
+});
+
+it('calls a private static method', function () {
+    $returnValue = invadeStatic(Example::class)
+        ->method('privateMethod')
+        ->call('test', 123);
+
+    expect($returnValue)->toBe('private return value test 123');
+});


### PR DESCRIPTION
Add `invadeStatic()` allowing to also invade private static properties and methods.
I suggested this a while ago [on twitter](https://twitter.com/chrolear/status/1780891662232789306)

----------

__From the added README:__

Further, there is also `invadeStatic` to get and set private static class properties and call private static methods. Imagine having this class:

```php
class MyClass
{
    private static string $privateProperty = 'privateValue';

    private static function privateMethod(string $string, int $int): string
    {
        return 'private return value ' . $string . ' ' . $int;
    }
}
```

Here is how you get and set private class properties:

```php
invadeStatic(MyClass::class)->get('privateProperty'); // returns 'private value'

invadeStatic(MyClass::class)->set('privateProperty', 'changedValue');

invadeStatic(MyClass::class)->get('privateProperty'); // returns 'changedValue'
```

And this is how you call private static methods:

```php
invadeStatic(MyClass::class)
    ->method('privateMethod')
    ->call('foo', 123);

// returns 'private return value foo 123'
```