### PR TITLE
Invading a does not allow access to its parent methods

### DIFF
--- a/tests/Base.php
+++ b/tests/Base.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Spatie\Invade\Tests;
+
+class Base
+{
+    private string $basePrivateProperty = 'basePrivateValue';
+
+    private function basePrivateMethod(): string {
+        return 'base private method';
+    }
+}

--- a/tests/InvaderSuperclassTest.php
+++ b/tests/InvaderSuperclassTest.php
@@ -1,0 +1,13 @@
+<?php
+
+beforeEach(function () {
+    $this->class = new class extends \Spatie\Invade\Tests\Base {
+
+    };
+});
+
+it('can call the private method of an object', function () {
+    $returnValue = invade($this->class)->basePrivateMethod();
+
+    expect($returnValue)->toBe('base private method');
+});


### PR DESCRIPTION
Previously in v1 invading a class that extends another would allow access to the parent private methods, however this no longer works in v2. This test case passes against the v1 branch.