### PR TITLE
test(call): verify exception for unset method case

### DIFF
--- a/tests/StaticInvaderTest.php
+++ b/tests/StaticInvaderTest.php
@@ -2,6 +2,8 @@
 
 namespace Spatie\Invade\Tests;
 
+use BadMethodCallException;
+
 beforeEach(function () {
     if (invade(Example::class)->get('privateStaticProperty') === 'changedValue') {
         invade(Example::class)->set('privateStaticProperty', 'privateValue');
@@ -28,4 +30,10 @@ it('calls a private static method', function () {
         ->call('test', 123);
 
     expect($returnValue)->toBe('private return value test 123');
+});
+
+it('throws an exception when trying to call a method without setting it first', function () {
+    expect(function () {
+        invade(Example::class)->call();
+    })->toThrow(BadMethodCallException::class, 'No method to be called. Use it like: invadeStatic(Foo::class)->method(\'bar\')->call()');
 });


### PR DESCRIPTION
- Add test case checking that call() throws BadMethodCallException when no method was specified
- Verify both exception type and message content